### PR TITLE
Add additional Prometheus metrics within privtrak

### DIFF
--- a/privtrak.go
+++ b/privtrak.go
@@ -20,7 +20,9 @@ func init() {
 	// Register the metrics.
 	prometheus.MustRegister(
 		PromGCDurationMilliseconds,
-		PromUsersCount)
+		PromUsersCount,
+		PromUpBytesTotal,
+		PromDownBytesTotal)
 }
 
 var (
@@ -37,6 +39,16 @@ var (
 	PromUsersCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "chihaya_privtrak_users_count",
 		Help: "The number of users tracked",
+	})
+
+	PromUpBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "chihaya_privtrak_traffic_up_bytes_total",
+		Help: "Total traffic transferred up, in bytes",
+	})
+
+	PromDownBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "chihaya_privtrak_traffic_down_bytes_total",
+		Help: "Total traffic transferred down, in bytes",
 	})
 )
 


### PR DESCRIPTION
There's some metrics that might be useful, and it's a good place to measure them from within an unlocked shard. So far the only one I think would be worth including by default is the total traffic up & down. Rather than two seperate counters there could be a single 'traffic' counter with 'up' & 'down' labels.

Also the names of the existing metrics for GC time and total users tracked don't conform with the Prometheus [best practices for naming](https://prometheus.io/docs/practices/naming/): GC time should be measured in seconds rather than ms, and the users name should end with 'total' rather than 'count'. Not sure if that's something you're interested in changing, its just for consistency with metrics from other applications.